### PR TITLE
Inherit color group names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export function extractColorVars(colorObj: ColorObjectType, colorGroup = '', pre
         ? {
             [cssVariable]: mode === 'hex' ? value : parseColor(value)?.color.join(', '),
           }
-        : extractColorVars(value, `-${colorKey}`, prefix, mode)
+        : extractColorVars(value, `${colorGroup}-${colorKey}`, prefix, mode)
 
     return { ...vars, ...newVars }
   }, {})


### PR DESCRIPTION
Thanks for the neat plugin!
I had some issues with nested colors like:
```
sem: {
        danger: {
          DEFAULT: '#E63C1C',
          hover: '#E63C1C',
          disabled: '#F9CEC6',
        },
        success: {
          DEFAULT: '#36B373',
          hover: '#1B5A3A',
          disabled: '#CDECDF',
        },
        warning: {
          DEFAULT: '#DB6629',
          hover: '#6E3315',
          disabled: '#EFA680'
        },
},
```
It would strip the parent color name from the variables which could cause some issues if you had multiple nested colors share the same name. It is also inconsistent with the tailwind usage.
"bg-sem-danger" would relate to "--tw-danger".
With the patch it should be "--tw-sem-danger".

Thanks a lot again.