### PR TITLE
Fix syntax for argument-less `require` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ module.exports = {
     // ...
   },
   plugins: [
-    require('@tailwind-plugin/expose-colors'),
+    require('@tailwind-plugin/expose-colors')(),
     // ...
   ],
 }


### PR DESCRIPTION
Unless I was doing something wrong, the argument-less version of the require doesn't work as-written. Have to call it.